### PR TITLE
Atom: Update raw package-list.txt plugin versions

### DIFF
--- a/docs/editor-plugins.md
+++ b/docs/editor-plugins.md
@@ -43,31 +43,31 @@ Get information about packages on https://atom.io/packages/.
 See also https://discuss.atom.io/t/installed-packages-list-into-single-file/12227/2.
 
 ```
-Sublime-Style-Column-Selection@1.7.2
-afterglow-monokai-syntax@1.3.4
-atom-jade@0.3.0
-atom-jsfmt@0.8.5
-atom-pair@2.0.10
-blackboard@1.0.0
-cobalt@0.3.0
-dash@1.6.2
-docblockr@0.8.5
-file-icons@1.7.19
-fizzy@0.16.0
-gist-it@0.9.1
-git-plus@5.17.0
-language-javascript-jsx@0.3.7
-linter@1.11.16
-linter-eslint@7.3.1
-linter-python-pep8@0.2.0
-merge-conflicts@1.4.4
-minimap@4.25.0
-mocha-test-runner@0.5.1
-motepair@0.21.0
-pigments@0.34.0
-pretty-json@1.6.0
-regex-railroad-diagram@0.16.0
-seti-ui@1.3.2
+Sublime-Style-Column-Selection
+afterglow-monokai-syntax
+atom-jade
+atom-jsfmt
+atom-pair
+blackboard
+cobalt
+dash
+docblockr
+file-icons
+fizzy
+gist-it
+git-plus
+language-javascript-jsx
+linter
+linter-eslint
+linter-python-pep8
+merge-conflicts
+minimap
+mocha-test-runner
+motepair
+pigments
+pretty-json
+regex-railroad-diagram
+seti-ui
 ```
 
 

--- a/docs/editor-plugins.md
+++ b/docs/editor-plugins.md
@@ -52,22 +52,22 @@ blackboard@1.0.0
 cobalt@0.3.0
 dash@1.3.2
 docblockr@0.7.3
-file-icons@1.6.9
+file-icons@1.7.19
 fizzy@0.16.0
 gist-it@0.8.0
-git-plus@5.4.7
+git-plus@5.16.2
 language-javascript-jsx@0.3.7
 linter@1.8.1
 linter-eslint@3.1.1
 linter-python-pep8@0.2.0
 merge-conflicts@1.3.6
-minimap@4.13.4
+minimap@4.25.0
 mocha-test-runner@0.4.4
 motepair@0.21.0
-pigments@0.15.0
+pigments@0.34.0
 pretty-json@0.4.1
 regex-railroad-diagram@0.10.3
-seti-ui@0.8.0
+seti-ui@1.3.2
 ```
 
 
@@ -77,5 +77,5 @@ If you use Sublime Text as your editor, you may find these plugins from [Sublime
 
 - [jsfmt](https://packagecontrol.io/packages/jsfmt) a sublime plugin for [jsfmt](http://rdio.github.io/jsfmt/). Helps to keep a consistent code style for your JavaScript. [Install via Package Control](https://github.com/ionutvmi/sublime-jsfmt#installation)
 - [SublimeLinter-jshint](https://packagecontrol.io/packages/SublimeLinter-jshint) a sublime plugin for the language-agnostic [SublimeLinter](https://packagecontrol.io/packages/SublimeLinter) plugin, using [jshint](http://jshint.com/). Checks for common mistakes and problems in your JavaScript code, like globally defined variables, missing semicolons, etc. Make sure to follow the installation steps listed on the [website](https://packagecontrol.io/packages/SublimeLinter-jshint).
-- [Jade](https://packagecontrol.io/packages/Jade) Syntax highlighing for .jade files (html templates)
+- [Jade](https://packagecontrol.io/packages/Jade) Syntax highlighting for .jade files (html templates)
 - [Less](https://packagecontrol.io/packages/LESS) Syntax highlighting for .less files (css meta language)

--- a/docs/editor-plugins.md
+++ b/docs/editor-plugins.md
@@ -43,30 +43,30 @@ Get information about packages on https://atom.io/packages/.
 See also https://discuss.atom.io/t/installed-packages-list-into-single-file/12227/2.
 
 ```
-Sublime-Style-Column-Selection@1.3.0
-afterglow-monokai-syntax@1.3.3
+Sublime-Style-Column-Selection@1.7.2
+afterglow-monokai-syntax@1.3.4
 atom-jade@0.3.0
-atom-jsfmt@0.8.3
+atom-jsfmt@0.8.5
 atom-pair@2.0.10
 blackboard@1.0.0
 cobalt@0.3.0
-dash@1.3.2
-docblockr@0.7.3
+dash@1.6.2
+docblockr@0.8.5
 file-icons@1.7.19
 fizzy@0.16.0
-gist-it@0.8.0
-git-plus@5.16.2
+gist-it@0.9.1
+git-plus@5.17.0
 language-javascript-jsx@0.3.7
-linter@1.8.1
-linter-eslint@3.1.1
+linter@1.11.16
+linter-eslint@7.3.1
 linter-python-pep8@0.2.0
-merge-conflicts@1.3.6
+merge-conflicts@1.4.4
 minimap@4.25.0
-mocha-test-runner@0.4.4
+mocha-test-runner@0.5.1
 motepair@0.21.0
 pigments@0.34.0
-pretty-json@0.4.1
-regex-railroad-diagram@0.10.3
+pretty-json@1.6.0
+regex-railroad-diagram@0.16.0
 seti-ui@1.3.2
 ```
 


### PR DESCRIPTION
e.g. `fileicons@1.6.9` no longer installs and prints in red text `Package version: 1.6.9 not found`, so it has been bumped to `1.7.19`

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongodb-js/mongodb-js/4)

<!-- Reviewable:end -->
